### PR TITLE
removing nltk dependency from the split_sentences function

### DIFF
--- a/pyteaser.py
+++ b/pyteaser.py
@@ -200,13 +200,22 @@ def keywords(text):
 
 
 def split_sentences(text):
-    #split a large string into sentences
-    import nltk.data  # natural language split sentences
-    tokenizer = nltk.data.load('tokenizers/punkt/english.pickle')
-    #text = re.sub(r'[^\w .]', '', text)
-    sentences = tokenizer.tokenize(text)
-    sentences = [x.replace('\n', '') for x in sentences if len(x) > 10]
-    return sentences
+    '''
+    The regular expression matches all sentence ending punctuation and splits the string at those points.
+    At this point in the code, the list looks like this ["Hello, world", "!" ... ]. The punctuation and all quotation marks
+    are separated from the actual text. The first s_iter line turns each group of two items in the list into a tuple,
+    excluding the last item in the list (the last item in the list does not need to have this performed on it). Then,
+    the second s_iter line combines each tuple in the list into a single item and removes any whitespace at the beginning
+    of the line. Now, the s_iter list is formatted correctly but it is missing the last item of the sentences list. The
+    second to last line adds this item to the s_iter list and the last line returns the full list.
+    '''
+    import re
+    sentences = re.split('(?<![A-Z])([.!?]"?)(?=\s+\"?[A-Z])',text)
+    s_iter = zip(*[iter(sentences[:-1])] * 2)
+    s_iter = [''.join(map(str,y)).lstrip() for y in s_iter]
+    s_iter.append(sentences[-1])
+    return s_iter
+
 
 
 def length_score(sentence):


### PR DESCRIPTION
I reworked the split_sentences function at line 202 so that it no longer depends on the nltk library. With this function I am able to recreate the example you have in your readme file. In the testing I've done it seems to work just fine, but there might be some edge cases I haven't discovered yet.

In my forked version, I included a version of python-goose that also has no nltk dependenceis. It was only required for one function that is not used in your code. You can check it out here https://github.com/tgallant/PyTeaser
