### PR TITLE
adding requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-e git+https://github.com/tgallant/python-goose.git#egg=python-goose


### PR DESCRIPTION
I forked the python goose repository and removed all nltk dependencies there as well. They only used it for one function for parsing Arabic, so deleting it didn't harm anything. I updated their dependencies to exclude nltk.

The requirements.txt file I am requesting to add pulls from my python-goose fork and installs everything that is needed. I've tested it on two machines and it works just fine. 

Now all anyone has to do to get started with PyTeaser is run pip install -r requirements.txt 
