### PR TITLE
adding cookies support

### DIFF
--- a/goose/network.py
+++ b/goose/network.py
@@ -21,7 +21,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import urllib2
-
+import cookielib
 
 class HtmlFetcher(object):
 
@@ -37,6 +37,10 @@ class HtmlFetcher(object):
         """
         if isinstance(url, unicode):
             url = url.encode('utf-8')
+        
+        cookiejar = cookielib.LWPCookieJar()
+        opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookiejar))
+        urllib2.install_opener(opener)
 
         headers = {'User-agent': config.browser_user_agent}
         request = urllib2.Request(url, headers=headers)


### PR DESCRIPTION
adding cookies support. I can now run SummarizeUrl on nytimes articles and other sites that require cookies. This does not hinder any other functionality or add any dependencies.
