### PR TITLE
Fixed Python unicode support.

### DIFF
--- a/pyteaser.py
+++ b/pyteaser.py
@@ -215,7 +215,7 @@ def split_sentences(text):
     
     sentences = regex_split('(?<![A-Z])([.!?]"?)(?=\s+\"?[A-Z])', text)
     s_iter = zip(*[iter(sentences[:-1])] * 2)
-    s_iter = [''.join(map(str,y)).lstrip() for y in s_iter]
+    s_iter = [''.join(map(unicode,y)).lstrip() for y in s_iter]
     s_iter.append(sentences[-1])
     return s_iter
 


### PR DESCRIPTION
Fixes issue #25

Allows Unicode support.

For example:

```
import pyteaser
pyteaser.Summarize(u'Título', u'Artículo. Contenido.')
```

Results in:

```
[u' Contenido.', u'Art\xedculo.']
```

Instead of:

```
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "C:\Users\LVELEZ\Anaconda\lib\site-packages\pyteaser.py", line 86, in Summarize
sentences = split_sentences(text)
File "C:\Users\LVELEZ\Anaconda\lib\site-packages\pyteaser.py", line 215, in split_sentences
s_iter = [''.join(map(str,y)).lstrip() for y in s_iter]
UnicodeEncodeError: 'ascii' codec can't encode character u'\xed' in position 3:
ordinal not in range(128)
>>> pyteaser.Summarize(u'Título', u'Artículo. Contenido.')
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "C:\Users\LVELEZ\Anaconda\lib\site-packages\pyteaser.py", line 86, in Summarize
sentences = split_sentences(text)
File "C:\Users\LVELEZ\Anaconda\lib\site-packages\pyteaser.py", line 215, in split_sentences
s_iter = [''.join(map(str,y)).lstrip() for y in s_iter]
UnicodeEncodeError: 'ascii' codec can't encode character u'\xed' in position 3:ordinal not in range(128)
```
