### PR TITLE
Improved time complexity (speeds up Summarize() by about 8 times for the test case)

### DIFF
--- a/pyteaser.py
+++ b/pyteaser.py
@@ -2,7 +2,7 @@ from collections import Counter
 from math import fabs
 from re import split as regex_split, sub as regex_sub
 
-stopWords = [
+stopWords = set([
     "-", " ", ",", ".", "a", "e", "i", "o", "u", "t", "about", "above",
     "above", "across", "after", "afterwards", "again", "against", "all",
     "almost", "alone", "along", "already", "also", "although", "always",
@@ -59,7 +59,7 @@ stopWords = [
     "january", "february", "march", "april", "may", "june", "july",
     "august", "september", "october", "november", "december",
     "philippine", "government", "police", "manila"
-]
+])
 ideal = 20.0
 
 


### PR DESCRIPTION
Testing for membership in a list is linear time, while testing membership in a set is constant time. The draw back is that we introduce a one time linear overhead when converting a list to a set, but since we test for membership multiple times for every word in an article, the conversion is worthwhile.

```
bv PyTeaser (master)$ python -m timeit -s "from pyteaser import Summarize; article_title = '{{title from test.py}}'; article_text = '{{283 words from test.py}}'" "Summarize(article_title, article_text)"
100 loops, best of 3: 16.2 msec per loop
bv PyTeaser (master)$ vi pyteaser.py #made the 5 character change
bv PyTeaser (master)$ git add ; git commit
bv PyTeaser (master)$ python -m timeit -s "from pyteaser import Summarize; article_title = '{{title from test.py}}'; article_text = '{{283 words from test.py}}'" "Summarize(article_title, article_text)"
1000 loops, best of 3: 1.88 msec per loop
```

Also minor readability fixes by using python's smarter </>/>= statements.
