### PR TITLE
Removed "philippine" and "manila" from stopwords

### DIFF
--- a/pyteaser.py
+++ b/pyteaser.py
@@ -59,7 +59,7 @@ stopWords = set([
     "yung", "yun", "2", "3", "4", "5", "6", "7", "8", "9", "0", "time",
     "january", "february", "march", "april", "may", "june", "july",
     "august", "september", "october", "november", "december",
-    "philippine", "government", "police", "manila"
+    "government", "police"
 ])
 ideal = 20.0
 


### PR DESCRIPTION
Some news articles about Philippines and Manila are important. There is no reason to have them as stop words on the main repository. If you want to put specific countries and cities on your stop words list, then please do so on a separate branch and not on the main repository.
