### PR TITLE
docs: Fix a few typos

### DIFF
--- a/goose/__init__.py
+++ b/goose/__init__.py
@@ -73,7 +73,7 @@ class Goose(object):
             )
 
         # test to write a dummy file to the directory
-        # to check is directory is writtable
+        # to check is directory is writable
         path = os.path.join(self.config.local_storage_path, 'test.txt')
         try:
             f = open(path, 'w')

--- a/goose/article.py
+++ b/goose/article.py
@@ -61,7 +61,7 @@ class Article(object):
         self.top_image = None
 
         # holds a set of tags that may have
-        # been in the artcle, these are not meta keywords
+        # been in the article, these are not meta keywords
         self.tags = set()
 
         # holds a list of any movies

--- a/goose/configuration.py
+++ b/goose/configuration.py
@@ -42,7 +42,7 @@ class Configuration(object):
         # interface to build your own
         self.enable_image_fetching = True
 
-        # set this valriable to False if you want to force
+        # set this variable to False if you want to force
         # the article language. OtherWise it will attempt to
         # find meta language and use the correct stopwords dictionary
         self.use_meta_language = True
@@ -53,7 +53,7 @@ class Configuration(object):
         # be use
         self.target_language = 'en'
 
-        # defautl stopwrods class
+        # default stopwrods class
         self.stopwords_class = StopWords
 
         # path to your imagemagick convert executable,

--- a/goose/crawler.py
+++ b/goose/crawler.py
@@ -89,10 +89,10 @@ class Crawler(object):
         # big stuff
         article.top_node = extractor.calculate_best_node(article)
         if article.top_node is not None:
-            # video handeling
+            # video handling
             video_extractor = self.get_video_extractor(article)
             video_extractor.get_videos()
-            # image handeling
+            # image handling
             if self.config.enable_image_fetching:
                 image_extractor = self.get_image_extractor(article)
                 article.top_image = image_extractor.get_best_image(article.raw_doc, article.top_node)
@@ -144,5 +144,5 @@ class Crawler(object):
             try:
                 os.remove(fname)
             except OSError:
-                # TODO better log handeling
+                # TODO better log handling
                 pass

--- a/goose/extractors.py
+++ b/goose/extractors.py
@@ -55,7 +55,7 @@ class ContentExtractor(object):
         Returns the language is by the article or
         the configuration language
         """
-        # we don't want to force the target laguage
+        # we don't want to force the target language
         # so we use the article.meta_lang
         if self.config.use_meta_language == True:
             if article.meta_lang:
@@ -215,7 +215,7 @@ class ContentExtractor(object):
     def extract_tags(self, article):
         node = article.doc
 
-        # node doesn't have chidren
+        # node doesn't have children
         if len(list(node)) == 0:
             return NO_STRINGS
 
@@ -313,7 +313,7 @@ class ContentExtractor(object):
         it should be connected to other paragraphs,
         at least for the first n paragraphs so we'll want to make sure that
         the next sibling is a paragraph and has at
-        least some substatial weight to it
+        least some substantial weight to it
         """
         para = "p"
         steps_away = 0

--- a/goose/outputformatters.py
+++ b/goose/outputformatters.py
@@ -38,7 +38,7 @@ class OutputFormatter(object):
         Returns the language is by the article or
         the configuration language
         """
-        # we don't want to force the target laguage
+        # we don't want to force the target language
         # so we use the article.meta_lang
         if self.config.use_meta_language == True:
             if article.meta_lang:

--- a/goose/text.py
+++ b/goose/text.py
@@ -133,7 +133,7 @@ class StopWordsChinese(StopWords):
     Chinese segmentation
     """
     def __init__(self, language='zh'):
-        # force zh languahe code
+        # force zh language code
         super(StopWordsChinese, self).__init__(language='zh')
 
     def candiate_words(self, stripped_input):
@@ -149,7 +149,7 @@ class StopWordsArabic(StopWords):
     Arabic segmentation
     """
     def __init__(self, language='ar'):
-        # force ar languahe code
+        # force ar language code
         super(StopWordsArabic, self).__init__(language='ar')
 
     def remove_punctuation(self, content):

--- a/goose/videos/extractors.py
+++ b/goose/videos/extractors.py
@@ -109,7 +109,7 @@ class VideoExtractor(object):
             self.candidates.remove(child_embed_tag[0])
 
         # get the object source
-        # if wa don't have a src node don't coninue
+        # if wa don't have a src node don't continue
         src_node = self.parser.getElementsByTag(node, tag="param", attr="name", value="movie")
         if not src_node:
             return None

--- a/pyteaser.py
+++ b/pyteaser.py
@@ -89,7 +89,7 @@ def Summarize(title, text):
     if len(sentences) <= 5:
         return sentences
 
-    #score setences, and use the top 5 sentences
+    #score sentences, and use the top 5 sentences
     ranks = score(sentences, titleWords, keys).most_common(5)
     for rank in ranks:
         summaries.append(rank[0])


### PR DESCRIPTION
There are small typos in:
- goose/__init__.py
- goose/article.py
- goose/configuration.py
- goose/crawler.py
- goose/extractors.py
- goose/outputformatters.py
- goose/text.py
- goose/videos/extractors.py
- pyteaser.py

Fixes:
- Should read `handling` rather than `handeling`.
- Should read `language` rather than `languahe`.
- Should read `language` rather than `laguage`.
- Should read `writable` rather than `writtable`.
- Should read `variable` rather than `valriable`.
- Should read `substantial` rather than `substatial`.
- Should read `sentences` rather than `setences`.
- Should read `default` rather than `defautl`.
- Should read `continue` rather than `coninue`.
- Should read `children` rather than `chidren`.
- Should read `article` rather than `artcle`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md